### PR TITLE
Display bgp routing instead of ip routing table

### DIFF
--- a/routers/huawei.php
+++ b/routers/huawei.php
@@ -36,10 +36,10 @@ class Huawei extends Router {
     $cmd->add('display');
 
     if (match_ipv6($parameter, false)) {
-      $cmd->add('ipv6');
+      $cmd->add('bgp ipv6');
     }
     if (match_ipv4($parameter, false)) {
-      $cmd->add('ip');
+      $cmd->add('bgp');
     }
     $parameter = str_replace('/', ' ', $parameter);
     $cmd->add('routing-table', $parameter);


### PR DESCRIPTION
<!--
  Thank you for your interest in contributing to Looking Glass.

  Please note that our contribution policy requires that a feature request or
  bug report be opened for approval prior to filing a pull request.

  Please indicate the feature request or bug report below. If your pull
  request does not reference an accepted bug report or feature request, it will
  be marked as invalid and closed.
-->
Resolves #131
### Fixes:
Change bgp routing command to show useful bgp information.

Currently only immediate next hop and direct interface are shown from normal routing table
![image](https://user-images.githubusercontent.com/20816134/91185833-95ea8100-e6ee-11ea-863a-dc6eec0383a5.png)


Whereas valid BGP information can be viewed by altering the command slightly;
![image](https://user-images.githubusercontent.com/20816134/91185785-866b3800-e6ee-11ea-9dc5-81c25ac1c1e3.png)


<!--
  Please include a summary of the proposed changes below.
-->

| Before | After |
| --- | ----------- |
| display ipv6 routing-table {parameter} | display bgp ipv6 routing-table {parameter} |
| display ip routing-table {parameter} | display bgp routing-table {parameter} |